### PR TITLE
Make dzil add link to github issues

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,3 +10,4 @@ version = 0.04
 [PkgVersion]
 [AutoPrereqs]
 [GithubMeta]
+    issues = 1


### PR DESCRIPTION
I'm on the OSDC course run by Gabor and one of the things he would like is the  "students" to do pull request, specifically with regard to [adding a link to GitHub issues](https://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributions) and I had an entertaining time trying to figure out how this was done via dzil.

Fixes #8